### PR TITLE
Make npm package private

### DIFF
--- a/default/package.json
+++ b/default/package.json
@@ -2,6 +2,7 @@
   "version": "1.0.0",
   "description": "This package.json is provided for development purposes, to set up the required development dependencies for linting and testing.",
   "main": "index.js",
+  "private": true,
   "dependencies": {
     "frint": "^1.3.0",
     "frint-react": "^1.3.0",


### PR DESCRIPTION
An accidental `npm publish` can push your code to the public.

Adding a `private` key in `package.json` helps avoid that.