### PR TITLE
Bugfix name of options

### DIFF
--- a/default/ui/helloWorldWidget/components/Root.js
+++ b/default/ui/helloWorldWidget/components/Root.js
@@ -49,8 +49,8 @@ const Root = React.createClass({
 
 export default observe(function doObserve(app) {
   return streamProps({})
-    .set('appName', app.getOption('name'))
-    .set('appId', app.getOption('id'))
+    .set('appName', app.getOption('appName'))
+    .set('appId', app.getOption('appId'))
     .set('shoppingCartService', app.get('shoppingCart'))
     .get$();
 })(Root);


### PR DESCRIPTION
We were retrieving `id` instead of `appid`. Also, changed `name` (which is the name of the widget) to `appname`, which is the name of the app.